### PR TITLE
Add optional arguement for allowImplicitSelfTransition

### DIFF
--- a/spec/TypeStateSpec.ts
+++ b/spec/TypeStateSpec.ts
@@ -263,4 +263,15 @@ describe('A finite state machine', ()=>{
       expect(fsm.currentState).toBe(ValidStates.B);
       expect(receivedData).toBe(eventData);
    });
+
+   it('doesn\'t allow states to transition into themselves by default', () => {
+       expect(fsm.canGo(ValidStates.A)).toBe(false);
+   });
+
+   it('can allow states to transition into themselves by default', () => {
+       var fsm2 = new TypeState.FiniteStateMachine<ValidStates>(ValidStates.A, true);
+       expect(fsm2.canGo(ValidStates.A)).toBe(true);
+   });
+
+
 });


### PR DESCRIPTION
This option if set to true (defaulted false) will allow states to implicitly transition into themselves.
eonarheim/TypeState#16

This is my first time really writing typescript and I haven't used the Jasmine test suite before, so please check this code carefully before accepting it.