### PR TITLE
[chore] Add prefix calls to tsc

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -95,7 +95,7 @@ module.exports = function (grunt) {
          // Execute TypeScript compiler against typestate core
          //
          tsc: {
-            command: 'npx tsc --sourcemap --declaration "./src/typestate.ts"',               
+            command: 'node_modules/.bin/tsc --sourcemap --declaration "./src/typestate.ts"',               
             options: {
                stdout: true,
                failOnError: true
@@ -103,7 +103,7 @@ module.exports = function (grunt) {
          },
 
          tscnode: {
-            command: 'npx tsc --sourcemap --module commonjs --declaration "./src/typestate-node.ts" --outDir "./dist/"',               
+            command: 'node_modules/.bin/tsc --sourcemap --module commonjs --declaration "./src/typestate-node.ts" --outDir "./dist/"',               
             options: {
                stdout: true,
                failOnError: true
@@ -114,7 +114,7 @@ module.exports = function (grunt) {
          // Execute TypeScript compiler against Excalibur core
          //
          example: {
-            command: 'npx tsc --sourcemap --module system --declaration "./example/example.ts"',               
+            command: 'node_modules/.bin/tsc --sourcemap --module system --declaration "./example/example.ts"',               
             options: {
                stdout: true,
                failOnError: true
@@ -136,7 +136,7 @@ module.exports = function (grunt) {
          // TODO: Simplify this so we don't have to always update it every time we add a spec
          //
          specs: {
-            command: 'npx tsc "./spec/TypeStateSpec.ts"',
+            command: 'node_modules/.bin/tsc "./spec/TypeStateSpec.ts"',
             options: {
                stdout: true,
                failOnError: true

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -95,7 +95,7 @@ module.exports = function (grunt) {
          // Execute TypeScript compiler against typestate core
          //
          tsc: {
-            command: 'tsc --sourcemap --declaration "./src/typestate.ts"',               
+            command: 'npx tsc --sourcemap --declaration "./src/typestate.ts"',               
             options: {
                stdout: true,
                failOnError: true
@@ -103,7 +103,7 @@ module.exports = function (grunt) {
          },
 
          tscnode: {
-            command: 'tsc --sourcemap --module commonjs --declaration "./src/typestate-node.ts" --outDir "./dist/"',               
+            command: 'npx tsc --sourcemap --module commonjs --declaration "./src/typestate-node.ts" --outDir "./dist/"',               
             options: {
                stdout: true,
                failOnError: true
@@ -114,7 +114,7 @@ module.exports = function (grunt) {
          // Execute TypeScript compiler against Excalibur core
          //
          example: {
-            command: 'tsc --sourcemap --module system --declaration "./example/example.ts"',               
+            command: 'npx tsc --sourcemap --module system --declaration "./example/example.ts"',               
             options: {
                stdout: true,
                failOnError: true
@@ -136,7 +136,7 @@ module.exports = function (grunt) {
          // TODO: Simplify this so we don't have to always update it every time we add a spec
          //
          specs: {
-            command: 'tsc "./spec/TypeStateSpec.ts"',
+            command: 'npx tsc "./spec/TypeStateSpec.ts"',
             options: {
                stdout: true,
                failOnError: true


### PR DESCRIPTION
to use the version of tsc in `node_modules/.bin/`

Not sure if this is a good idea, since npx requires npm v5.2.0 or later.

At least thats what I needed to add to be able to run all the grunt tasks.
I could have also hardcoded it with a 'node_modules/.bin/ ' prefix...